### PR TITLE
Add namespace to ObjC class name

### DIFF
--- a/bindings/spm/Sources/Verovio/VRVBundleHelper.h
+++ b/bindings/spm/Sources/Verovio/VRVBundleHelper.h
@@ -1,5 +1,5 @@
 //
-//  BundleHelper.h
+//  VRVBundleHelper.h
 //  
 //
 //  Created by Joshua Elkins on 8/2/21.
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 
-@interface BundleHelper: NSObject
+@interface VRVBundleHelper: NSObject
 
 /// For some reason, SPM's generated bundle accessor helper method
 /// isn't accessible from a .mm file (the static function that retrieves

--- a/bindings/spm/Sources/Verovio/VRVBundleHelper.m
+++ b/bindings/spm/Sources/Verovio/VRVBundleHelper.m
@@ -1,14 +1,14 @@
 //
-//  BundleHelper.m
+//  VRVBundleHelper.m
 //  
 //
 //  Created by Joshua Elkins on 8/2/21.
 //
 
-#import "BundleHelper.h"
+#import "VRVBundleHelper.h"
 
 
-@implementation BundleHelper
+@implementation VRVBundleHelper
 
 + (NSBundle *)bundleForModule {
     return SWIFTPM_MODULE_BUNDLE;

--- a/bindings/spm/Sources/Verovio/VerovioWrapper.mm
+++ b/bindings/spm/Sources/Verovio/VerovioWrapper.mm
@@ -1,7 +1,7 @@
 #import "VerovioWrapper.h"
 #import <dispatch/dispatch.h>
 #import "../../../../include/vrv/toolkit.h"
-#import "BundleHelper.h"
+#import "VRVBundleHelper.h"
 
 
 @implementation Verovio
@@ -13,7 +13,7 @@ static dispatch_queue_t renderQueue = dispatch_queue_create("com.rism.Verovio.sh
 - (NSString *)renderFirstPageForURL:(NSURL *)url withOptions:(NSDictionary *)options {
     NSString * __block svg;
     dispatch_sync(renderQueue, ^{
-        NSBundle * verovioBundle = [BundleHelper bundleForModule];
+        NSBundle * verovioBundle = [VRVBundleHelper bundleForModule];
         NSString * resourcePath = [verovioBundle URLsForResourcesWithExtension:@"xml" subdirectory:@"data"].firstObject.URLByDeletingLastPathComponent.path;
         vrv::Resources::SetPath([resourcePath cStringUsingEncoding:NSUTF8StringEncoding]);
         if (!vrv::Resources::InitFonts()) {


### PR DESCRIPTION
Renamed the `BundleHelper` class to `VRVBundleHelper` to avoid class name collisions elsewhere in iOS, i.e.:
```
objc[30692]: Class BundleHelper is implemented in both 
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CVNLP.framework/CVNLP (0x7fff8394e620)
and
/Users/josh/Library/Developer/Xcode/DerivedData/Trala-cwtvbzpmldmroqbpyxviwgynuvde/Build/Products/Debug-iphonesimulator/PackageFrameworks/Verovio.framework/Verovio (0x1130bd2e0).
One of the two will be used. Which one is undefined.
```